### PR TITLE
makefile and GitHub workflow automation bootstrap examples

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,72 @@
+name: build
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+
+env:
+  DESTDIR: ./bin
+
+jobs:
+
+  #
+  # Tests for all platforms. Runs a matrix build on Windows, Linux and Mac,
+  # with the list of expected supported Go versions (current, previous).
+  #
+
+  build:
+    name: Build and test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        go-version: [ 1.21.5 ]
+        target: [ "ci-build", ]
+    runs-on: ${{ matrix.os }}
+    steps:
+
+      # Install go: https://github.com/actions/setup-go/releases/tag/v4.1.0
+      - name: Install go
+        uses: actions/setup-go@v4.1.0
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+
+      # Set go bin
+      #- name: Setup Go binary path
+      #  shell: bash
+      #  run: |
+      #    echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+      #    echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      # Fix git lien endings
+      - name: Git line endings
+        shell: bash
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      # Checkout code: https://github.com/actions/checkout/releases/tag/v4.1.1
+      - name: Check out main code into the Go module directory
+        uses: actions/checkout@v4.1.1
+      #  with:
+      #    ref: ${{ github.event.pull_request.head.sha }}
+      #    path: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}
+
+
+      # Build using make
+      - name: make ${{ matrix.target }}
+        shell: bash
+        run: |
+          make $target
+      #  working-directory: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}
+        env:
+      #    CONFIG_PASSWORD: secretzSoSecureYouWontBelieveIt999
+          target: ${{ matrix.target }}
+          #          CONFIG_PASSWORD: ${{ secrets.CONFIG_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 nohup.out
 
 galene-ldap
+galene-ldap.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *~
+.bin
+.data
+nohup.out
+
 galene-ldap

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ print:
 	@echo ""
 
 ci-build: 
+	# You can call this locally. github workflow also calls it.
 	@echo ""
 	@echo "CI BUILD starting ..."
 	$(MAKE) print 
@@ -63,7 +64,7 @@ DATA_EXAMPLE=examples/02/galene-ldap.json
 data-bootstrap: data
 	# cp in config
 	# change to choose what example you want to use...
-	$(REPO_CMD) cp $(DATA_EXAMPLE) $(DATA)
+	cp $(DATA_EXAMPLE) $(DATA)
 
 	# TODO: cp in certs...Gen with mkcert.
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+
+
+BIN_ROOT=$(PWD)/.bin
+BIN=$(BIN_ROOT)/galene-ldap
+
+DATA_ROOT=$(PWD)/.data
+DATA=$(DATA_ROOT)/galene-ldap.json
+
+print:
+	@echo ""
+	@echo "BIN_ROOT:  $(BIN_ROOT)"
+	@echo ""
+	@echo "DATA_ROOT: $(DATA_ROOT)"
+	@echo ""
+	@echo ""
+
+
+upgrade:
+	# https://github.com/oligot/go-mod-upgrade
+	# https://github.com/oligot/go-mod-upgrade/releases/tag/v0.9.1
+	go install github.com/oligot/go-mod-upgrade@v0.9.1
+
+	go-mod-upgrade
+	go mod tidy
+
+build:
+	CGO_ENABLED=1 go build -o $(BIN) .
+build-del:
+	rm -rf $(BIN_ROOT)
+
+data:
+	mkdir -p $(DATA_ROOT)
+data-del:
+	rm -rf $(DATA_ROOT)
+data-bootstrap: data
+	# cp in config
+	$(REPO_CMD) cp examples/02/galene-ldap.json $(DATA)
+	# cp in certs...
+
+run-h:
+	$(BIN) -h
+run:
+	nohup $(BIN) -debug -data $(DATA) &
+	#  http://localhost:8088
+

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,34 @@
+OS_GO_BIN_NAME=go
+ifeq ($(shell uname),Windows)
+	OS_GO_BIN_NAME=go.exe
+endif
 
+OS_GO_OS=$(shell $(OS_GO_BIN_NAME) env GOOS)
+# toggle to fake being windows..
+#OS_GO_OS=windows
 
 BIN_ROOT=$(PWD)/.bin
 BIN=$(BIN_ROOT)/galene-ldap
+ifeq ($(OS_GO_OS),windows)
+	BIN=$(BIN_ROOT)/galene-ldap.exe
+endif
 
 DATA_ROOT=$(PWD)/.data
 DATA=$(DATA_ROOT)/galene-ldap.json
 
 print:
 	@echo ""
+	@echo "OS_GO_BIN_NAME:  $(OS_GO_BIN_NAME)"
+	@echo ""
+	@echo "OS_GO_OS:  $(OS_GO_OS)"
+	@echo ""
 	@echo "BIN_ROOT:  $(BIN_ROOT)"
+	@echo "BIN:       $(BIN)"
 	@echo ""
 	@echo "DATA_ROOT: $(DATA_ROOT)"
+	@echo "DATA:      $(DATA)"
 	@echo ""
-	@echo ""
+
 
 
 upgrade:
@@ -34,12 +50,15 @@ data-del:
 	rm -rf $(DATA_ROOT)
 data-bootstrap: data
 	# cp in config
+	# change to choose what example you want to use...
 	$(REPO_CMD) cp examples/02/galene-ldap.json $(DATA)
-	# cp in certs...
+
+	# TODO: cp in certs...Gen with mkcert.
 
 run-h:
 	$(BIN) -h
 run:
 	nohup $(BIN) -debug -data $(DATA) &
-	#  http://localhost:8088
+
+	# http://localhost:8088
 

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ upgrade:
 
 	go-mod-upgrade
 	go mod tidy
+ci-build: build
 
 build:
 	CGO_ENABLED=1 go build -o $(BIN) .

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,11 @@ endif
 DATA_ROOT=$(PWD)/.data
 DATA=$(DATA_ROOT)/galene-ldap.json
 
-print:
+.PHONY: help
+help: # Show help for each of the Makefile recipes.
+	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+
+print: # print for local system
 	@echo ""
 	@echo "OS_GO_BIN_NAME:  $(OS_GO_BIN_NAME)"
 	@echo ""
@@ -29,11 +33,12 @@ print:
 	@echo "DATA:      $(DATA)"
 	@echo ""
 
-ci-build: 
+ci-build: # build for local system and ci
 	# You can call this locally. github workflow also calls it.
 	# Its calling everything in the makefile ...
 	@echo ""
 	@echo "CI BUILD starting ..."
+	$(MAKE) help 
 	$(MAKE) print 
 	$(MAKE) clean-all
 	$(MAKE) build-debug
@@ -42,7 +47,7 @@ ci-build:
 	@echo ""
 	@echo "CI BUILD ended ...."
 
-clean-all: data-clean build-clean
+clean-all: data-clean build-clean # cleans all data and binaries
 
 upgrade:
 	# https://github.com/oligot/go-mod-upgrade
@@ -51,35 +56,35 @@ upgrade:
 	go-mod-upgrade
 	go mod tidy
 
-build-init:
+build-init: # init binaries
 	mkdir -p $(BIN_ROOT)
-build-clean:
+build-clean: # clean binaries
 	rm -rf $(BIN_ROOT)
-build: build-init
+build: build-init # build release binaries
 	CGO_ENABLED=1 go build -o $(BIN) .
-build-debug: build-init
+build-debug: build-init # build debug binaries
 	CGO_ENABLED=1 go build -ldflags='-s -w' -o $(BIN) .
 
 
-data-init:
+data-init: # init data folder
 	mkdir -p $(DATA_ROOT)
-data-clean:
+data-clean: # clean data folder
 	rm -rf $(DATA_ROOT)
 
 # toggle to choose what example you want to use...
 #DATA_EXAMPLE=examples/01/galene-ldap.json
 DATA_EXAMPLE=examples/02/galene-ldap.json
-data-bootstrap: data-init
+data-bootstrap: data-init # create data
 	cp $(DATA_EXAMPLE) $(DATA)
 
 	# TODO: cp in certs...Gen with mkcert.
 
-run-h:
+run-h: # run to show help
 	$(BIN) -h
-run:
+run: # run release
 	$(BIN) -data $(DATA_ROOT)
 	# http://localhost:8088
-run-debug:
+run-debug: # run debug
 	nohup $(BIN) -debug -data $(DATA_ROOT) &
 	# http://localhost:8088
 

--- a/Makefile
+++ b/Makefile
@@ -29,16 +29,25 @@ print:
 	@echo "DATA:      $(DATA)"
 	@echo ""
 
+ci-build: 
+	@echo ""
+	@echo "CI BUILD starting ..."
+	$(MAKE) print 
+	$(MAKE) clean
+	$(MAKE) build
+	$(MAKE) data-bootstrap
+	$(MAKE) run
+	@echo ""
+	@echo "CI BUILD ended ...."
 
+clean: data-del build-del
 
 upgrade:
 	# https://github.com/oligot/go-mod-upgrade
 	# https://github.com/oligot/go-mod-upgrade/releases/tag/v0.9.1
 	go install github.com/oligot/go-mod-upgrade@v0.9.1
-
 	go-mod-upgrade
 	go mod tidy
-ci-build: build
 
 build:
 	CGO_ENABLED=1 go build -o $(BIN) .
@@ -49,10 +58,12 @@ data:
 	mkdir -p $(DATA_ROOT)
 data-del:
 	rm -rf $(DATA_ROOT)
+
+DATA_EXAMPLE=examples/02/galene-ldap.json
 data-bootstrap: data
 	# cp in config
 	# change to choose what example you want to use...
-	$(REPO_CMD) cp examples/02/galene-ldap.json $(DATA)
+	$(REPO_CMD) cp $(DATA_EXAMPLE) $(DATA)
 
 	# TODO: cp in certs...Gen with mkcert.
 
@@ -60,6 +71,5 @@ run-h:
 	$(BIN) -h
 run:
 	nohup $(BIN) -debug -data $(DATA) &
-
 	# http://localhost:8088
 

--- a/README
+++ b/README
@@ -2,6 +2,10 @@ Galene-ldap: LDAP integration for the Galene videoconferencing server.
 
 For more information about Galene, please see <https://galene.org>.
 
+0. Use the Makefile
+
+or use the steps below.
+
 1. Build galene-ldap
 
     CGO_ENABLED=0 go build -ldflags='-s -w'

--- a/examples/01/README.md
+++ b/examples/01/README.md
@@ -1,1 +1,1 @@
-just the basic example
+just the basic example from the README

--- a/examples/01/README.md
+++ b/examples/01/README.md
@@ -1,0 +1,1 @@
+just the basic example

--- a/examples/01/galene-ldap.json
+++ b/examples/01/galene-ldap.json
@@ -3,5 +3,5 @@
     "ldapServer": "ldap://localhost:389",
     "ldapBase": "ou=users,dc=yunohost,dc=org",
     "key": {"alg":"HS256","k":"xxx","key_ops":["sign","verify"],"kty":"oct"},
-    "groups": ["test-auth"],
+    "groups": ["test-auth"]
 }

--- a/examples/01/galene-ldap.json
+++ b/examples/01/galene-ldap.json
@@ -1,0 +1,7 @@
+{
+    "httpAddress": ":8444",
+    "ldapServer": "ldap://localhost:389",
+    "ldapBase": "ou=users,dc=yunohost,dc=org",
+    "key": {"alg":"HS256","k":"xxx","key_ops":["sign","verify"],"kty":"oct"},
+    "groups": ["test-auth"],
+}

--- a/examples/02/README.md
+++ b/examples/02/README.md
@@ -1,1 +1,4 @@
-config for using with galene
+config for using with galene from https://github.com/zerolabnet/galene-ldap
+
+This currently fails because zerolabnet changed the data structs a little.
+Should merge in his changes...

--- a/examples/02/README.md
+++ b/examples/02/README.md
@@ -1,0 +1,1 @@
+config for using with galene

--- a/examples/02/galene-ldap.json
+++ b/examples/02/galene-ldap.json
@@ -1,0 +1,15 @@
+{
+    "httpAddress": ":8444",
+    "ldapServer": "ldap://ldap.example.org:389",
+    "ldapBase": "OU=users,DC=domain,DC=example,DC=org",
+    "ldapClientSideValidate": false,
+    "ldapAuthDN": "CN=users-sync,OU=spec,OU=users,DC=domain,DC=example,DC=org",
+    "ldapAuthPassword": "secret_pwd",
+    "passwordFallback": true,
+    "key": {"alg":"HS256","k":"xxx","key_ops":["sign","verify"],"kty":"oct"},
+    "groups-exception": [""],
+    "op": [
+        {"group": "groupname1", "username": ["username1","username2"]},
+        {"group": "groupname2", "username": ["username1","username2"]}
+    ]
+}


### PR DESCRIPTION
would like to PR this in if thats ok.

It just takes what your README.md says and codifies it to a Makefile that is also callable from GitHub workflows. See make ci.build target !

README. Just adds the use of the Makefile, so devs know its there if they want it.

makefile and is OS independent

GitHub ci workflow that builds for all OS by leveraging the makefile that is OS independent.
Action run  in my fork: https://github.com/gedw99/galene-ldap/actions

Next up is getting tagging and releases working, and also testing integration with galena to make it easier for users.