### PR TITLE
Allow configuration of permissions.

### DIFF
--- a/README
+++ b/README
@@ -100,6 +100,8 @@ The `galene-ldap.json` file may contain the following fields:
     anonymous BIND;
   - `ldapClientSideValidate`, if true, then we validate passwords in the
     client; by default, we validate passwords by attempting a BIND.
+  - `defaultPermissions`: the permissions to give to users.  If not set,
+    it defaults to `["present", "message"]`.
 
 -- Juliusz Chroboczek
 

--- a/token.go
+++ b/token.go
@@ -100,7 +100,7 @@ func parseKey(key map[string]interface{}) (string, interface{}, error) {
 	}
 }
 
-func makeToken(alg string, key interface{}, issuer, location, username, password string) (string, error) {
+func makeToken(alg string, key interface{}, issuer, location, username, password string, permissions []string) (string, error) {
 	now := time.Now()
 
 	m := make(map[string]interface{})
@@ -113,7 +113,7 @@ func makeToken(alg string, key interface{}, issuer, location, username, password
 	if username != "" {
 		m["sub"] = username
 	}
-	m["permissions"] = []string{"present", "message"}
+	m["permissions"] = permissions
 	m["iat"] = now.Add(-time.Second).Unix()
 	m["exp"] = now.Add(30 * time.Second).Unix()
 

--- a/token_test.go
+++ b/token_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"reflect"
 
 	"github.com/golang-jwt/jwt/v5"
 )
@@ -33,6 +34,7 @@ func TestSign(t *testing.T) {
 
 		token, err := makeToken(
 			alg, key, "issuer", "location", "username", "password",
+			[]string{"present", "message"},
 		)
 		if err != nil {
 			t.Errorf("Couldn't generate token %v: %v", i, err)
@@ -54,3 +56,29 @@ func TestSign(t *testing.T) {
 		}
 	}
 }
+
+func TestConfigurationPermissions(t *testing.T) {
+	var c configuration
+	err := json.Unmarshal([]byte("{}"), &c)
+	if err != nil {
+		t.Errorf("Unmarshal: %v", err)
+	}
+	if c.DefaultPermissions.set {
+		t.Errorf("Permissions are set")
+	}
+
+	err = json.Unmarshal([]byte(`{"defaultPermissions": ["admin"]}`), &c)
+	if err != nil {
+		t.Errorf("Unmarshal: %v", err)
+	}
+	if !c.DefaultPermissions.set {
+		t.Errorf("Permissions are not set")
+	}
+	if !reflect.DeepEqual(
+		c.DefaultPermissions.permissions, []string{"admin"},
+	) {
+		t.Errorf("Expected admin, got %v",
+			c.DefaultPermissions.permissions)
+	}
+}
+


### PR DESCRIPTION
Since we need to distinguish null permissions from unset permissions,
this requires a custom JSON unmarshaller.

Co-Author: Baptiste Daroussin <bapt@FreeBSD.org>

Supersedes #6.
