### PR TITLE
Allow configuration of user's entry objectClass

### DIFF
--- a/README
+++ b/README
@@ -102,6 +102,8 @@ The `galene-ldap.json` file may contain the following fields:
     client; by default, we validate passwords by attempting a BIND.
   - `defaultPermissions`: the permissions to give to users.  If not set,
     it defaults to `["present", "message"]`.
+  - `ldapObjectClass`: the objectClass of the user entry to search. If not
+    set, it defaults to `posixAccount`.
 
 -- Juliusz Chroboczek
 

--- a/galene-ldap.go
+++ b/galene-ldap.go
@@ -75,6 +75,7 @@ type configuration struct {
 	LdapBase               string                 `json:"ldapBase"`
 	LdapAuthDN             string                 `json:"ldapAuthDN"`
 	LdapAuthPassword       string                 `json:"ldapAuthPassword"`
+	LdapObjectClass        string                 `json:"ldapObjectClass"`
 	LdapClientSideValidate bool                   `json:"ldapClientSideValidate"`
 	DefaultPermissions     maybePermissions       `json:"defaultPermissions"`
 }
@@ -113,6 +114,10 @@ func main() {
 
 	if config.HttpAddress == "" {
 		config.HttpAddress = ":8443"
+	}
+
+	if config.LdapObjectClass == "" {
+		config.LdapObjectClass = "posixAccount"
 	}
 
 	// unbuffered, so we can discard requests
@@ -315,7 +320,7 @@ func verifier(ch <-chan verifyReq) {
 			ldapVerify(
 				conn, config.LdapClientSideValidate,
 				config.LdapAuthDN, config.LdapAuthPassword,
-				req.user, req.password)
+				req.user, config.LdapObjectClass, req.password)
 		if err != nil {
 			conn.Close()
 			conn = nil

--- a/ldap.go
+++ b/ldap.go
@@ -31,7 +31,7 @@ func ldapConnect(server, authDN, authPW string) (*ldap.Conn, error) {
 	return conn, nil
 }
 
-func ldapVerify(conn *ldap.Conn, clientside bool, authDN, authPW, user, password string) (bool, bool, error) {
+func ldapVerify(conn *ldap.Conn, clientside bool, authDN, authPW, user, objectclass, password string) (bool, bool, error) {
 	attrs := []string{"dn"}
 	if clientside {
 		attrs = append(attrs, "userPassword")
@@ -41,7 +41,8 @@ func ldapVerify(conn *ldap.Conn, clientside bool, authDN, authPW, user, password
 		ldap.ScopeWholeSubtree,
 		ldap.NeverDerefAliases,
 		0, 0, false,
-		fmt.Sprintf("(&(objectClass=posixAccount)(uid=%s))",
+		fmt.Sprintf("(&(objectClass=%s)(uid=%s))",
+			ldap.EscapeFilter(objectclass),
 			ldap.EscapeFilter(user)),
 		attrs,
 		nil,


### PR DESCRIPTION
The search filter `objectClass` is not necessarily a `posixAccount`. Make that custoomizable (and defaulting to `posixAccount`).

Actually it might be useful to make the attribute name `uid` customizable too.